### PR TITLE
[ADD] Service, Controller, Dto, Repository, Domain 초기 구현 완료

### DIFF
--- a/src/main/java/com/adela/controller/BoardApiController.java
+++ b/src/main/java/com/adela/controller/BoardApiController.java
@@ -1,0 +1,11 @@
+package com.adela.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequiredArgsConstructor
+@RestController
+public class BoardApiController {
+
+}

--- a/src/main/java/com/adela/domain/Article.java
+++ b/src/main/java/com/adela/domain/Article.java
@@ -1,0 +1,55 @@
+package com.adela.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Article {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "boardID", updatable = false)
+    private Long boardId;
+
+    @Column(name = "categoryID", nullable = false)
+    private Long categoryId;
+
+    @Column(name = "userID", nullable = false)
+    private Long userId;
+
+    @Column(name = "Title", nullable = false)
+    private String title;
+
+    @Column(name = "Content")
+    private String content;
+
+    @Column(name = "codeContent")
+    private String codeContent;
+
+    @Column(name = "errorContent")
+    private String errorContent;
+
+    @Column(name = "regDate", nullable = false)
+    private LocalDate regDate;
+
+    @Column(name = "updateDate")
+    private LocalDate updateDate;
+
+    @Builder
+    public Article(Long categoryId, Long userId, String title, String content, String codeContent, String errorContent, LocalDate regDate){
+        this.categoryId = categoryId;
+        this.userId = userId;
+        this.title = title;
+        this.content = content;
+        this.codeContent = codeContent;
+        this.errorContent = errorContent;
+        this.regDate = regDate;
+        this.updateDate = regDate;
+    }
+}

--- a/src/main/java/com/adela/dto/AddArticleRequest.java
+++ b/src/main/java/com/adela/dto/AddArticleRequest.java
@@ -1,0 +1,33 @@
+package com.adela.dto;
+
+import com.adela.domain.Article;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class AddArticleRequest {
+    private Long categoryId;
+    private Long userId;
+    private String title;
+    private String content;
+    private String codeContent;
+    private String errorContent;
+    private LocalDate regDate;
+
+    public Article toEntity(){
+        return Article.builder()
+                .categoryId(categoryId)
+                .userId(userId)
+                .title(title)
+                .content(content)
+                .codeContent(codeContent)
+                .errorContent(errorContent)
+                .regDate(regDate)
+                .build();
+    }
+}

--- a/src/main/java/com/adela/repository/BoardRepository.java
+++ b/src/main/java/com/adela/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package com.adela.repository;
+
+import com.adela.domain.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Article, Long> {
+}

--- a/src/main/java/com/adela/service/BoardService.java
+++ b/src/main/java/com/adela/service/BoardService.java
@@ -1,0 +1,9 @@
+package com.adela.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class BoardService {
+}


### PR DESCRIPTION
### Service, Controller, Dto, Repository, Domain

- 비즈니스 계층 = service 패키지
   - BoardService : 서비스 계층에서 게시글(Board) 관련 서비스 메서드 코드 처리하는 클래스
- 프레젠테이션 계층 = cotroller 패키지
   - BoardApiController : 게시글 관련 API 메서드를 관리하는 클래스
- 퍼시스턴스 계층 = repository 패키지
   - BoardRepository : DB의 Board 테이블에 관한 sql 관련 처리를 사용하게 해주는 인터페이스
- 데이터베이스와 연결되는 DAO = domin 패키지
   - Article : DB 내에 Board 테이블과 직접 연동되는 클래스
- 계층끼리 데이터를 교환하기 위한 객체 = dto 패키지
   - AddArticleRequest : Board 데이터를 계층끼리 교환하기 위한 클래스
